### PR TITLE
Fix: add vscode setting (prettier)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit"
+  }
+}

--- a/prettierrc.json
+++ b/prettierrc.json
@@ -1,5 +1,0 @@
-{
-  "printWidth": 120,
-  "singleQuote": true,
-  "semi": false
-}


### PR DESCRIPTION
Added a configuration file because the VS code settings are not included.
In the configuration file formatter is esbenp.prettier-vscode.