### PR TITLE
Fix: プ譜インポートエラー

### DIFF
--- a/src/components/ProjectScore.tsx
+++ b/src/components/ProjectScore.tsx
@@ -73,9 +73,9 @@ export const ProjectScore = ({
               }
               return false;
             })
-            .reduce((a, b) => a || b);
+            .reduce((a, b) => a || b, false);
         })
-        .reduce((a, b) => a || b);
+        .reduce((a, b) => a || b, false);
     }
     return false;
   };


### PR DESCRIPTION
## 概要

空の `measures` 配列を持つ中間目的がある JSON データをインポートすると、「Reduce of empty array with no initial value」エラーが発生する問題を修正しました。

## 問題

Storybook の Example1 で、施策が空の中間目的を含む JSON をインポートすると以下のエラーが発生していました：

```
TypeError: Reduce of empty array with no initial value
```

## 原因

`hideMeasure` 関数内で `measures` 配列に対して初期値なしで `reduce` を呼び出していたため、空配列の場合にエラーが発生していました。

## 修正内容

`reduce` メソッドに初期値 `false` を追加しました。

```diff
- .reduce((a, b) => a || b);
+ .reduce((a, b) => a || b, false);
```

## 影響範囲

- `src/components/ProjectScore.tsx`

## テスト

- 空の `measures` 配列を持つ JSON のインポートが正常に動作することを確認
- ` storybook-build-test `で既存の機能に影響がないことを確認
