### PR TITLE
Fix: 施策の進捗インジケーター表示と2カラムレスポンシブ対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goto-lab/pufu-editor",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "description": "Web editor component for Project score (Pufu).",
   "main": "dist/index.js",
   "repository": {

--- a/src/components/Edges.tsx
+++ b/src/components/Edges.tsx
@@ -4,8 +4,9 @@ import { ProjectScoreMap } from "../lib/models";
 export interface EdgesProps {
   scoreKey: string;
   scores: ProjectScoreMap;
-  action: boolean;
+  action: number;
   preview: boolean;
+  connectMeasureUuids?: Set<string>; // 右列の施策UUID一覧（2カラム時の線描画制御用）
 }
 
 interface Position {
@@ -27,6 +28,7 @@ export const Edges = ({
   scores,
   action,
   preview = false,
+  connectMeasureUuids,
 }: EdgesProps) => {
   const [viewBox, setViewBox] = useState("0 0 0 0");
   const [edges, setEdges] = useState<PostionSet[]>([]);
@@ -86,6 +88,12 @@ export const Edges = ({
     if (score.purposes.length > 0) {
       score.purposes.forEach((purpose) => {
         purpose.measures.forEach((measure) => {
+          // connectMeasureUuidsが指定されている場合、右列の施策のみ線を描画
+          if (connectMeasureUuids && !connectMeasureUuids.has(measure.uuid)) {
+            purposeMapping.push({ measure: measure.uuid, purpose: purpose.uuid });
+            measureTexts.push(measure.text);
+            return;
+          }
           if (measure.text && measureTexts.includes(measure.text)) {
             edges.push([
               `${scoreKey}-measure-${measure.uuid}`,

--- a/src/components/Measure.tsx
+++ b/src/components/Measure.tsx
@@ -28,6 +28,7 @@ export interface MeasureProps {
   preview?: boolean;
   dark?: boolean;
   mobile?: boolean;
+  showProgress?: boolean;
   i18n?: i18n;
   textSize?: TextSize;
 }
@@ -42,12 +43,14 @@ export const Measure = ({
   preview = false,
   dark = false,
   mobile = false,
+  showProgress = false,
   i18n,
   textSize = "small",
 }: MeasureProps) => {
   const [text, setText] = useState(measure.text);
   const [color, setColor] = useState(measure.color);
   const [comment, setComment] = useState(measure.comment);
+  const [progress, setProgress] = useState(measure.progress);
   const [showComment, setShowComment] = useState(
     preview && measure.comment.text.length > 0
   );
@@ -77,36 +80,47 @@ export const Measure = ({
     onChange?.({ ...measure, color });
   };
 
+  const handleProgressChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value === '' ? undefined : Math.max(0, Math.min(100, Number(e.target.value)));
+    setProgress(value);
+    onChange?.({ ...measure, progress: value });
+  };
+
   const colors = {
     white: {
       border: "border-gray-400",
       icon: "text-gray-400",
       pallet: "text-gray-400",
       bg: "bg-white dark:bg-gray-900",
+      progressBg: "bg-gray-400",
     },
     blue: {
       border: "border-sky-400",
       icon: "text-sky-400",
       pallet: "text-sky-400",
       bg: "bg-sky-50 dark:bg-sky-900",
+      progressBg: "bg-sky-400",
     },
     green: {
       border: "border-green-500",
       icon: "text-green-500",
       pallet: "text-green-400",
       bg: "bg-green-50 dark:bg-green-900",
+      progressBg: "bg-green-500",
     },
     red: {
       border: "border-red-300",
       icon: "text-red-300",
       pallet: "text-red-400",
       bg: "bg-red-50 dark:bg-red-900",
+      progressBg: "bg-red-300",
     },
     yellow: {
       border: "border-yellow-500",
       icon: "text-yellow-500",
       pallet: "text-yellow-400",
       bg: "bg-yellow-50 dark:bg-yellow-900",
+      progressBg: "bg-yellow-500",
     },
   };
 
@@ -116,6 +130,7 @@ export const Measure = ({
     setText(measure.text);
     setColor(measure.color);
     setComment(measure.comment);
+    setProgress(measure.progress);
   }, [measure]);
 
   return hidden ? (
@@ -132,7 +147,7 @@ export const Measure = ({
           relative
           rounded
           border px-1 py-2
-          text-center 
+          text-center
         ${colors[color].border}
         ${colors[color].bg}
       `}
@@ -237,8 +252,8 @@ export const Measure = ({
           <IoChatboxEllipsesOutline
             className={`
               absolute -bottom-2 -right-1
-              rounded-md bg-white 
-              dark:bg-gray-900 
+              rounded-md bg-white
+              dark:bg-gray-900
               ${colors[color].icon} hover:cursor-pointer
             `}
             size={25}
@@ -249,6 +264,42 @@ export const Measure = ({
             role="measure"
             aria-label="comment-icon"
           />
+        )}
+        {/* 進捗インジケーター（showProgress有効時のみ表示） */}
+        {showProgress && preview && progress !== undefined && (
+          <div className="mt-1 px-1 pb-1" role="measure" aria-label="progress">
+            <div className="flex items-center gap-1">
+              <span className="text-xs text-gray-400 dark:text-gray-500">進捗</span>
+              <div className="h-1.5 flex-1 rounded-full bg-gray-200 dark:bg-gray-700">
+                <div
+                  className={`h-1.5 rounded-full ${colors[color].progressBg}`}
+                  style={{ width: `${progress}%` }}
+                />
+              </div>
+              <span className="min-w-[2rem] text-right text-xs text-gray-500 dark:text-gray-300">
+                {progress}%
+              </span>
+            </div>
+          </div>
+        )}
+        {showProgress && !preview && (
+          <div className="relative z-20 mt-1 px-1 pb-1" role="measure" aria-label="progress-edit">
+            <div className="flex items-center justify-end gap-1">
+              <span className="text-xs text-gray-400 dark:text-gray-500">進捗</span>
+              <input
+                type="number"
+                min={0}
+                max={100}
+                value={progress ?? ''}
+                placeholder="-"
+                onChange={handleProgressChange}
+                className="w-10 bg-transparent text-right text-xs text-gray-500 outline-none dark:text-gray-300 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                role="measure"
+                aria-label="progress-input"
+              />
+              <span className="text-xs text-gray-500 dark:text-gray-300">%</span>
+            </div>
+          </div>
         )}
       </div>
       {(feedback || preview) && showComment && (

--- a/src/components/ProjectScore.tsx
+++ b/src/components/ProjectScore.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useRef } from "react";
+import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { ReactSortable } from "react-sortablejs";
 import domtoimage from "dom-to-image";
 import modelsTI from "../lib/models-ti";
@@ -22,6 +22,7 @@ export interface ProjectScoreProps {
   preview?: boolean;
   dark?: boolean;
   mobile?: boolean;
+  showProgress?: boolean;
   lang?: SupportLanguage;
   textSize?: TextSize;
   width?: number;
@@ -37,6 +38,7 @@ export const ProjectScore = ({
   preview = false,
   dark = false,
   mobile = false,
+  showProgress = false,
   lang = "ja",
   textSize = "small",
   width,
@@ -45,9 +47,9 @@ export const ProjectScore = ({
   const [scoreKey] = useState(uniqueKey ?? createScoreKey());
   const scoreRef = useRef<HTMLDivElement | null>(null);
 
-  const [action, setAction] = useState(false);
+  const [action, setAction] = useState(0);
   const updateAction = () => {
-    setAction(!action);
+    setAction((prev) => prev + 1);
   };
 
   state = useProjectScoreStoreEffect(scoreKey, updateAction, initScore);
@@ -80,6 +82,75 @@ export const ProjectScore = ({
     return false;
   };
 
+  // 2カラム表示かどうかを判定（施策エリアの幅が十分ある場合のみ）
+  const [isTwoColumn, setIsTwoColumn] = useState(false);
+  const observerRef = useRef<ResizeObserver | null>(null);
+  const measuresRef = useCallback((node: HTMLDivElement | null) => {
+    // 前のobserverをクリーンアップ
+    if (observerRef.current) {
+      observerRef.current.disconnect();
+      observerRef.current = null;
+    }
+    if (!node || mobile) {
+      setIsTwoColumn(false);
+      return;
+    }
+    const checkWidth = () => {
+      // 施策エリア（w-1/2）の幅が280px未満なら1カラムに切り替え
+      const measuresWidth = node.clientWidth / 2;
+      setIsTwoColumn(measuresWidth >= 280);
+    };
+    checkWidth();
+    observerRef.current = new ResizeObserver(checkWidth);
+    observerRef.current.observe(node);
+  }, [mobile]);
+
+  // カラム数変更時にEdgesの線を再描画（DOM確定後に実行）
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      updateAction();
+    });
+  }, [isTwoColumn]);
+
+  // 右列（中間目的に近い列）の施策UUIDを算出（2カラム時、線の接続対象）
+  // actionを依存配列に含めることで施策の追加・削除・並び替え時にも再計算される
+  const connectMeasureUuids = useMemo(() => {
+    if (!isTwoColumn || !(scoreKey in state.scores)) return undefined;
+    const uuids = new Set<string>();
+
+    // 共有施策テキストを特定（複数purposeに存在するテキスト）
+    const textPurposeCount = new Map<string, number>();
+    state.scores[scoreKey].purposes.forEach((p) => {
+      const seen = new Set<string>();
+      p.measures.forEach((m) => {
+        if (m.text && !seen.has(m.text)) {
+          seen.add(m.text);
+          textPurposeCount.set(m.text, (textPurposeCount.get(m.text) || 0) + 1);
+        }
+      });
+    });
+    const isSharedText = (text: string) => text && (textPurposeCount.get(text) || 0) > 1;
+
+    state.scores[scoreKey].purposes.forEach((p) => {
+      // 共有施策は常に右列（接続対象）
+      // 通常施策は2カラムグリッドの右列のみ接続対象
+      const normalMeasures = p.measures.filter((m) => !isSharedText(m.text));
+      const count = normalMeasures.length;
+      normalMeasures.forEach((m, idx) => {
+        if (count <= 1 || idx % 2 === 1 || idx === count - 1) {
+          uuids.add(m.uuid);
+        }
+      });
+      // 共有施策は常に接続対象
+      p.measures.forEach((m) => {
+        if (isSharedText(m.text)) {
+          uuids.add(m.uuid);
+        }
+      });
+    });
+    return uuids;
+  }, [scoreKey, isTwoColumn, action]);
+
   const scoreStyle = useMemo(() => {
     return width
       ? {
@@ -107,6 +178,7 @@ export const ProjectScore = ({
               scores={state.scores}
               action={action}
               preview={preview}
+              connectMeasureUuids={connectMeasureUuids}
             ></Edges>
           )}
           {!mobile && (
@@ -134,7 +206,7 @@ export const ProjectScore = ({
             border-gray-300 dark:border-gray-600
             `}
           >
-            <div className={`w-2/3`}>
+            <div className={`w-2/3`} ref={measuresRef}>
               <MeasurePurposeHeader i18n={i18n} />
               {!preview && state.scores[scoreKey].purposes.length === 0 && (
                 <div
@@ -151,6 +223,24 @@ export const ProjectScore = ({
                 </div>
               )}
               {state.scores[scoreKey].purposes.map((purpose, purposeIndex) => {
+                // 共有施策の判定（他のpurposeにも同じテキストが存在するか）
+                const otherTexts = new Set<string>();
+                state.scores[scoreKey].purposes.forEach((p, pIdx) => {
+                  if (pIdx !== purposeIndex) {
+                    p.measures.forEach((m) => {
+                      if (m.text) otherTexts.add(m.text);
+                    });
+                  }
+                });
+                const isSharedMeasure = (text: string) => text && otherTexts.has(text);
+                // 共有施策は最初のpurposeでのみ表示
+                const isFirstPurposeForText = (text: string) => {
+                  for (const p of state.scores[scoreKey].purposes) {
+                    if (p.measures.some((m) => m.text === text)) return p.uuid === purpose.uuid;
+                  }
+                  return false;
+                };
+
                 return (
                   <div
                     className={`
@@ -161,72 +251,142 @@ export const ProjectScore = ({
                   >
                     <div
                       className={`
-                        w-1/2
-                        ${mobile ? "px-2" : "pl-3 pr-6"} 
+                        w-1/2 overflow-hidden
+                        ${mobile ? "px-2" : "pl-3 pr-3"}
                         pt-3
                       `}
                     >
-                      <ReactSortable
-                        list={purpose.measures.map((m) => ({
-                          id: m.uuid,
-                          ...m,
-                        }))}
-                        setList={(measures) => {
-                          const before = purpose.measures
-                            .map((m) => m.uuid)
-                            .join();
-                          const after = measures.map((m) => m.uuid).join();
-                          if (before !== after) {
-                            state.setMeasures(scoreKey, purpose.uuid, measures);
-                            updateAction();
-                          }
-                        }}
-                        animation={150}
-                        delay={2}
-                        filter={"textarea"}
-                        preventOnFilter={false}
-                      >
-                        {purpose.measures.map((measure, measureIndex) => (
-                          <div
-                            key={`measure-${measure.uuid}`}
-                            className="pb-1"
-                            onClick={updateAction}
-                            onBlur={updateAction}
-                          >
-                            <Measure
-                              scoreKey={scoreKey}
-                              measure={measure}
-                              feedback={feedback}
-                              preview={preview}
-                              dark={dark}
-                              mobile={mobile}
-                              i18n={i18n}
-                              textSize={textSize}
-                              hidden={hideMeasure(
-                                purposeIndex,
-                                measureIndex,
-                                measure.text
-                              )}
-                              onChange={(measure) => {
-                                state.setMeasure(
-                                  scoreKey,
-                                  purpose.uuid,
-                                  measure
+                      {preview && isTwoColumn ? (
+                        /* プレビュー+2カラム時: 通常施策は2カラム、共有施策は右寄せ */
+                        <div className="grid grid-cols-2 gap-x-2">
+                          {(() => {
+                            const normalMeasures = purpose.measures
+                              .filter((m) => !isSharedMeasure(m.text));
+                            const items: React.ReactNode[] = [];
+                            let colPos = 0; // 現在のグリッド列位置（0=左, 1=右）
+                            let normalIdx = 0;
+                            purpose.measures.forEach((m) => {
+                              const shared = isSharedMeasure(m.text);
+                              if (shared && !isFirstPurposeForText(m.text)) return;
+                              if (shared) {
+                                // 共有施策は右列に配置。左列にいる場合のみスペーサー挿入
+                                if (colPos % 2 === 0) {
+                                  items.push(<div key={`spacer-${m.uuid}`} />);
+                                  colPos++;
+                                }
+                                items.push(
+                                  <div key={`measure-${m.uuid}`} className="pb-1">
+                                    <Measure scoreKey={scoreKey} measure={m}
+                                      feedback={feedback} preview={preview} dark={dark}
+                                      mobile={mobile} showProgress={showProgress}
+                                      i18n={i18n} textSize={textSize} hidden={false} />
+                                  </div>
                                 );
-                                updateAction();
-                              }}
-                              onDelete={(measure) => {
-                                state.deleteMeasure(
-                                  scoreKey,
-                                  purpose.uuid,
-                                  measure.uuid
+                                colPos++;
+                              } else {
+                                // 通常施策の最後が左列に来る場合、右寄せ
+                                const isLastNormal = normalIdx === normalMeasures.length - 1;
+                                const normalIsOdd = normalMeasures.length % 2 === 1;
+                                if (isLastNormal && normalIsOdd && colPos % 2 === 0) {
+                                  items.push(<div key={`spacer-${m.uuid}`} />);
+                                  colPos++;
+                                }
+                                items.push(
+                                  <div key={`measure-${m.uuid}`} className="pb-1">
+                                    <Measure scoreKey={scoreKey} measure={m}
+                                      feedback={feedback} preview={preview} dark={dark}
+                                      mobile={mobile} showProgress={showProgress}
+                                      i18n={i18n} textSize={textSize} hidden={false} />
+                                  </div>
                                 );
-                                updateAction();
-                              }}
-                            />
-                          </div>
-                        ))}
-                      </ReactSortable>
+                                colPos++;
+                                normalIdx++;
+                              }
+                            });
+                            return items;
+                          })()}
+                        </div>
+                      ) : (
+                        /* 編集モードまたは1カラム時 */
+                        <ReactSortable
+                          className={`${isTwoColumn ? 'grid grid-cols-2 gap-x-2' : ''}`}
+                          list={purpose.measures.map((m) => ({
+                            id: m.uuid,
+                            ...m,
+                          }))}
+                          setList={(measures) => {
+                            const before = purpose.measures
+                              .map((m) => m.uuid)
+                              .join();
+                            const after = measures.map((m) => m.uuid).join();
+                            if (before !== after) {
+                              state.setMeasures(scoreKey, purpose.uuid, measures);
+                              updateAction();
+                            }
+                          }}
+                          animation={150}
+                          delay={2}
+                          filter={"textarea,input"}
+                          preventOnFilter={false}
+                        >
+                          {(() => {
+                            const normalMeasures = purpose.measures
+                              .filter((m) => !isSharedMeasure(m.text));
+                            let normalIdx = 0;
+                            return purpose.measures.map((measure, measureIndex) => {
+                              const shared = isTwoColumn && isSharedMeasure(measure.text);
+                              let rightAlign = shared;
+                              if (!shared && isTwoColumn) {
+                                const isLastNormal = normalIdx === normalMeasures.length - 1;
+                                const normalIsOdd = normalMeasures.length % 2 === 1;
+                                if (isLastNormal && normalIsOdd) rightAlign = true;
+                                normalIdx++;
+                              }
+                              return (
+                            <div
+                              key={`measure-${measure.uuid}`}
+                              className={`pb-1 ${rightAlign ? 'col-start-2' : ''}`}
+                              onClick={updateAction}
+                              onBlur={updateAction}
+                            >
+                              <Measure
+                                scoreKey={scoreKey}
+                                measure={measure}
+                                feedback={feedback}
+                                preview={preview}
+                                dark={dark}
+                                mobile={mobile}
+                                showProgress={showProgress}
+                                i18n={i18n}
+                                textSize={textSize}
+                                hidden={hideMeasure(
+                                  purposeIndex,
+                                  measureIndex,
+                                  measure.text
+                                )}
+                                onChange={(measure) => {
+                                  state.setMeasure(
+                                    scoreKey,
+                                    purpose.uuid,
+                                    measure
+                                  );
+                                  updateAction();
+                                }}
+                                onDelete={(measure) => {
+                                  state.deleteMeasure(
+                                    scoreKey,
+                                    purpose.uuid,
+                                    measure.uuid
+                                  );
+                                  updateAction();
+                                }}
+                              />
+                            </div>
+                              );
+                            });
+                          })()}
+                        </ReactSortable>
+                      )}
                       {!preview && purpose.measures.length === 0 && (
                         <div
                           className={`
@@ -433,9 +593,13 @@ export const setScore = (key: string, json: string) => {
         if (purpose) purpose.measures = [];
         return;
       }
-      purpose.measures.forEach((measure: { color?: string } | null) => {
+      purpose.measures.forEach((measure: { color?: string; progress?: number } | null) => {
         if (measure && !measure.color) {
           measure.color = 'white';
+        }
+        // 進捗値のバリデーション
+        if (measure && measure.progress !== undefined) {
+          measure.progress = Math.max(0, Math.min(100, measure.progress));
         }
       });
     });
@@ -493,7 +657,7 @@ export const getScoreMarkdown = (key: string) => {
               .map((measure, measureIndex) => {
                 let measureText = replaceNL(
                   `    - 施策${purposeIndex + 1}-${measureIndex + 1}: `,
-                  measure.text
+                  measure.text + (measure.progress !== undefined ? ` (${measure.progress}%)` : '')
                 );
                 if (measure.comment.text) {
                   measureText += replaceNL(

--- a/src/lib/models-ti.ts
+++ b/src/lib/models-ti.ts
@@ -4,6 +4,8 @@
 import * as t from "ts-interface-checker";
 // tslint:disable:object-literal-key-quotes
 
+export const TextSize = t.union(t.lit("small"), t.lit("base"), t.lit("large"));
+
 export const CommentColor = t.union(t.lit("blue"), t.lit("green"), t.lit("red"));
 
 export const CommentModel = t.iface([], {
@@ -22,6 +24,7 @@ export const MeasureColor = t.union(t.lit("white"), t.lit("blue"), t.lit("green"
 export const MeasureModel = t.iface(["BaseModel"], {
   "id": t.opt("string"),
   "color": "MeasureColor",
+  "progress": t.opt("number"),
 });
 
 export const SortableMeasureModel = t.iface(["MeasureModel"], {
@@ -65,6 +68,7 @@ export const ProjectScoreMap = t.iface([], {
 export const SupportLanguage = t.union(t.lit("ja"), t.lit("en"));
 
 const exportedTypeSuite: t.ITypeSuite = {
+  TextSize,
   CommentColor,
   CommentModel,
   BaseModel,

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -18,6 +18,7 @@ export type MeasureColor = "white" | "blue" | "green" | "red" | "yellow";
 export interface MeasureModel extends BaseModel {
   id?: string;
   color: MeasureColor;
+  progress?: number; // 0-100の進捗率（Optional）
 }
 
 export interface SortableMeasureModel extends MeasureModel {

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -302,6 +302,9 @@ export const createProjectScoreStore = create<ProjectScoreStore>()(
               state.scores[key].purposes[purposeIndex].measures[
                 measureIndex
               ].comment = measure.comment;
+              state.scores[key].purposes[purposeIndex].measures[
+                measureIndex
+              ].progress = measure.progress;
             }
           }
         }

--- a/src/stories/1_ProjectScoreExamples.stories.tsx
+++ b/src/stories/1_ProjectScoreExamples.stories.tsx
@@ -35,6 +35,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 const key1 = "example1";
 const key2 = "example2";
+const key3 = "example3";
 
 const isMobile = () => {
   if (
@@ -47,7 +48,7 @@ const isMobile = () => {
   }
 };
 
-export const Example1: Story = {
+export const Example1_Preview: Story = {
   args: {
     uniqueKey: key1,
     initScore: exampleData,
@@ -100,7 +101,7 @@ export const Example1: Story = {
   },
 };
 
-export const Example2: Story = {
+export const Example2_Edit: Story = {
   args: {
     uniqueKey: key2,
     feedback: true,
@@ -185,6 +186,24 @@ export const Example2: Story = {
             }
           }}
         />
+      </>
+    );
+  },
+};
+
+export const Example3_ShowProgress: Story = {
+  args: {
+    uniqueKey: key3,
+    initScore: exampleData,
+    preview: true,
+    showProgress: true,
+    mobile: isMobile(),
+  },
+  render: function Comp({ ...args }) {
+    return (
+      <>
+        <p className="ml-8 mb-2">進捗インジケーター表示の例</p>
+        <meta.component {...args}></meta.component>
       </>
     );
   },

--- a/src/stories/2_ProjectScore.stories.tsx
+++ b/src/stories/2_ProjectScore.stories.tsx
@@ -9,12 +9,14 @@ import {
   editTest,
   feedbackTest,
   previewTest,
+  twoColumnTest,
+  showProgressTest,
 } from "../tests/ProjectScore.stories.test";
 import {
   createInitialScoreDataWithComment,
   createInitialScoreDataWithDuplication,
 } from "../tests/common";
-import { DownloadButton, ImportButton, ModalDialog } from "./common";
+import { DownloadButton, ImportButton, ModalDialog, exampleData } from "./common";
 
 const meta = {
   title: "pufu-editor/ProjectScore",
@@ -143,4 +145,21 @@ export const TextLarge: Story = {
     feedback: true,
     textSize: "large",
   },
+};
+
+export const TwoColumn: Story = {
+  args: {
+    initScore: exampleData,
+    preview: true,
+  },
+  play: twoColumnTest,
+};
+
+export const ShowProgress: Story = {
+  args: {
+    initScore: exampleData,
+    preview: true,
+    showProgress: true,
+  },
+  play: showProgressTest,
 };

--- a/src/stories/7_Measure.stories.tsx
+++ b/src/stories/7_Measure.stories.tsx
@@ -8,6 +8,8 @@ import {
   previewTest,
   textBaseTest,
   textLargeTest,
+  progressEditTest,
+  progressPreviewTest,
 } from "../tests/Measure.stories.test";
 import i18n from "../i18n/config";
 i18n.changeLanguage("ja");
@@ -184,6 +186,82 @@ export const Preview: Story = {
     );
   },
   play: previewTest,
+};
+
+export const WithProgress: Story = {
+  args: {
+    measure: {
+      uuid: "1234",
+      color: "green",
+      text: "",
+      comment: {
+        color: "blue",
+        text: "",
+      },
+      progress: 60,
+    },
+    i18n: i18n,
+  },
+  render: function Comp({ ...args }) {
+    const [measure, setMeasure] = useState<MeasureModel>({
+      uuid: "1234",
+      color: "green",
+      text: "OSSとしてコードを公開する",
+      comment: {
+        color: "blue",
+        text: "",
+      },
+      progress: 60,
+    });
+    return (
+      <meta.component
+        {...args}
+        measure={measure}
+        onChange={setMeasure}
+        showProgress={true}
+        i18n={i18n}
+      ></meta.component>
+    );
+  },
+  play: progressEditTest,
+};
+
+export const WithProgressPreview: Story = {
+  args: {
+    measure: {
+      uuid: "1234",
+      color: "red",
+      text: "",
+      comment: {
+        color: "blue",
+        text: "",
+      },
+      progress: 80,
+    },
+  },
+  render: function Comp({ ...args }) {
+    const [measure, setMeasure] = useState<MeasureModel>({
+      uuid: "1234",
+      color: "red",
+      text: "キックプ譜を開発する中で感じた機能的課題を解消する",
+      comment: {
+        color: "blue",
+        text: "",
+      },
+      progress: 80,
+    });
+    return (
+      <meta.component
+        {...args}
+        measure={measure}
+        onChange={setMeasure}
+        preview={true}
+        showProgress={true}
+        i18n={i18n}
+      ></meta.component>
+    );
+  },
+  play: progressPreviewTest,
 };
 
 export const TextBase: Story = {

--- a/src/stories/common.tsx
+++ b/src/stories/common.tsx
@@ -233,6 +233,7 @@ export const exampleData: ProjectScoreModel = {
             text: "",
           },
           color: "red",
+          progress: 75,
         },
         {
           uuid: "aUTXd41VA9FqT36QPDWhRW",
@@ -270,6 +271,7 @@ export const exampleData: ProjectScoreModel = {
             text: "",
           },
           color: "white",
+          progress: 40,
         },
         {
           uuid: "vhKMTEwnoN3CZLmVYfDqHB",
@@ -307,6 +309,7 @@ export const exampleData: ProjectScoreModel = {
             text: "",
           },
           color: "white",
+          progress: 100,
         },
       ],
     },
@@ -377,4 +380,26 @@ export const exampleData: ProjectScoreModel = {
       },
     },
   },
+};
+
+// 共有施策（テキスト重複）を含むサンプルデータ（2カラム表示確認用）
+export const exampleDataWithSharedMeasure: ProjectScoreModel = {
+  ...exampleData,
+  purposes: [
+    {
+      ...exampleData.purposes[0],
+      measures: [
+        ...exampleData.purposes[0].measures,
+        {
+          uuid: "shared-measure-1",
+          text: "プ譜の共有を通してプロジェクトに取り組む人たちを繋げ、その人達を活気づける",
+          comment: { color: "blue", text: "" },
+          color: "blue",
+          progress: 30,
+        },
+      ],
+    },
+    exampleData.purposes[1],
+    exampleData.purposes[2],
+  ],
 };

--- a/src/tests/Measure.stories.test.ts
+++ b/src/tests/Measure.stories.test.ts
@@ -180,3 +180,57 @@ export const textLargeTest = async ({ canvasElement }: StorybookTestProps) => {
   await expect(textbox).not.toHaveClass("text-base");
   await expect(textbox).toHaveClass("text-lg");
 };
+
+// 進捗インジケーター: 編集モードテスト
+export const progressEditTest = async ({ canvasElement }: StorybookTestProps) => {
+  const canvas = within(canvasElement);
+
+  // 施策ボックスが表示される
+  expect(
+    await canvas.findByRole("measure", { name: "box" })
+  ).toBeInTheDocument();
+
+  // 進捗編集エリアが表示される（showProgress=true）
+  const progressEdit = await canvas.findByRole("measure", { name: "progress-edit" });
+  expect(progressEdit).toBeInTheDocument();
+
+  // 進捗ラベルが表示される
+  expect(await canvas.findByText("進捗")).toBeInTheDocument();
+
+  // 進捗入力欄に値が表示される
+  const progressInput = await canvas.findByRole("measure", { name: "progress-input" });
+  expect(progressInput).toBeInTheDocument();
+  expect(progressInput).toHaveValue(60);
+
+  // 値を変更できる
+  await userEvent.clear(progressInput);
+  await userEvent.type(progressInput, "80");
+  expect(progressInput).toHaveValue(80);
+};
+
+// 進捗インジケーター: プレビューモードテスト
+export const progressPreviewTest = async ({ canvasElement }: StorybookTestProps) => {
+  const canvas = within(canvasElement);
+
+  // 施策ボックスが表示される
+  expect(
+    await canvas.findByRole("measure", { name: "box" })
+  ).toBeInTheDocument();
+
+  // プレビューモードの進捗表示エリアが表示される
+  const progressArea = await canvas.findByRole("measure", { name: "progress" });
+  expect(progressArea).toBeInTheDocument();
+
+  // 進捗ラベルが表示される
+  expect(await canvas.findByText("進捗")).toBeInTheDocument();
+
+  // パーセント表示がある
+  expect(await canvas.findByText("80%")).toBeInTheDocument();
+
+  // 編集用の入力欄は表示されない
+  expect(canvas.queryByRole("measure", { name: "progress-input" })).toBeNull();
+
+  // テキストは読み取り専用
+  const textbox = await canvas.findByRole("measure", { name: "textbox" });
+  expect(textbox).toHaveAttribute("readonly");
+};

--- a/src/tests/ProjectScore.stories.test.ts
+++ b/src/tests/ProjectScore.stories.test.ts
@@ -1,4 +1,4 @@
-import { within, userEvent, expect } from "@storybook/test";
+import { within, userEvent, expect, waitFor } from "@storybook/test";
 import {
   addMeasure,
   addMeasureByIcon,
@@ -542,4 +542,47 @@ export const previewTest = async ({ canvasElement }: StorybookTestProps) => {
     expect(commentTexbox).toHaveAttribute("readonly");
     expect(await canvas.findByDisplayValue(`施策${i + 1}のコメント`));
   }
+};
+
+// 2列表示テスト（プレビューモード）
+export const twoColumnTest = async ({ canvasElement }: StorybookTestProps) => {
+  const canvas = within(canvasElement);
+
+  // スコアが表示される
+  expect(await canvas.findByRole("score", { name: "box" })).toBeInTheDocument();
+
+  // 施策が表示される
+  const measures = await canvas.findAllByRole("measure", { name: "box" });
+  expect(measures.length).toBeGreaterThanOrEqual(2);
+
+  // 施策テキストが読み取り専用
+  const textboxes = await canvas.findAllByRole("measure", { name: "textbox" });
+  for (const textbox of textboxes) {
+    expect(textbox).toHaveAttribute("readonly");
+  }
+
+  // 中間目的が表示される
+  const purposes = await canvas.findAllByRole("purpose", { name: "box" });
+  expect(purposes.length).toBeGreaterThanOrEqual(1);
+};
+
+// 進捗インジケーター表示テスト（プレビューモード）
+export const showProgressTest = async ({ canvasElement }: StorybookTestProps) => {
+  const canvas = within(canvasElement);
+
+  // スコアが表示される
+  expect(await canvas.findByRole("score", { name: "box" })).toBeInTheDocument();
+
+  // 進捗バーが表示される（progress値が設定されている施策）
+  await waitFor(async () => {
+    const progressAreas = await canvas.findAllByRole("measure", { name: "progress" });
+    expect(progressAreas.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // 進捗ラベルが表示される
+  const progressLabels = await canvas.findAllByText("進捗");
+  expect(progressLabels.length).toBeGreaterThanOrEqual(1);
+
+  // パーセント表示がある（サンプルデータの75%）
+  expect(await canvas.findByText("75%")).toBeInTheDocument();
 };


### PR DESCRIPTION
## Summary

- 施策の進捗度合いをインジケータ＋%表示できる機能を追加（`showProgress` プロパティで制御）
- 横幅が広い場合に施策を2列で表示するレスポンシブ対応を追加
- 複数の中間目的に紐づく共有施策を右列に1つだけ表示し、接続線を適切に描画

## 進捗インジケーター

- `MeasureModel` に `progress?: number`（0-100）を追加
- `ProjectScore` に `showProgress` プロパティを追加（デフォルト `false`）
- プレビューモード: プログレスバー＋「進捗」ラベル＋%テキスト
- 編集モード: 「進捗」ラベル＋数値入力欄＋%テキスト
- Markdown出力・JSONインポート時のバリデーション対応

## 2カラムレスポンシブ対応

- `ResizeObserver` で施策エリアの幅を監視し、280px以上で2カラム表示に自動切替
- 各行で施策が1つの場合は右列（中間目的に近い側）に寄せて表示
- 共有施策（テキスト重複）は最初のpurposeの右列に1つだけ表示
- 接続線（Edges）は右列の施策のみに描画、共有施策は全関連purposeへ描画
- カラム数変更・施策編集時にエッジを確実に再描画

## 変更ファイル（13ファイル, +545 -76）

- `src/lib/models.ts`, `models-ti.ts`, `store.ts` — データモデル・ストア更新
- `src/components/Measure.tsx` — 進捗バーUI、`showProgress` 対応
- `src/components/ProjectScore.tsx` — 2カラムレイアウト、`showProgress` 対応
- `src/components/Edges.tsx` — 右列施策のみ線描画
- `src/stories/`, `src/tests/` — Storybook・テスト追加

## Test plan

- [x] `npm run build` でビルドエラーなし
- [x] `npm run lint` でリントエラーなし
- [x] `npm run storybook-test` で全56テストパス