### PR TITLE
Fix: Storybook Example1 title

### DIFF
--- a/src/stories/1_ProjectScoreExamples.stories.tsx
+++ b/src/stories/1_ProjectScoreExamples.stories.tsx
@@ -48,7 +48,7 @@ const isMobile = () => {
   }
 };
 
-export const Example1_Preview: Story = {
+export const Example1: Story = {
   args: {
     uniqueKey: key1,
     initScore: exampleData,


### PR DESCRIPTION
Storybookのパスを外部でも参照しているため、下記の戻し修正を実施。
変更前：pufu-editor-examples--example-1-preview
変更後：pufu-editor-examples--example-1