### PR TITLE
Fix: Storybook Example1 import refresh

### DIFF
--- a/src/components/ProjectScore.tsx
+++ b/src/components/ProjectScore.tsx
@@ -149,7 +149,7 @@ export const ProjectScore = ({
       });
     });
     return uuids;
-  }, [scoreKey, isTwoColumn, action]);
+  }, [scoreKey, isTwoColumn, action, state.scores]);
 
   const scoreStyle = useMemo(() => {
     return width


### PR DESCRIPTION
 ProjectScore.tsx:154 — connectMeasureUuids の useMemo 依存配列に
  state.scores を追加

  useMemo 内で state.scores[scoreKey].purposes
  を参照して施策UUIDを計算しているが、依存配列に state.scores
  が含まれていなかった。

  そのため setScore() でデータが差し替わっても connectMeasureUuids が再計
  算されず、旧データのUUIDセットが残り続ける。ブラウザではマウス操作で
  action が更新されるため顕在化しないが、Puppeteer（AWS
  Lambda画像生成）ではUI操作がないため action が変わらず、全施策の
  connectMeasureUuids.has(uuid) が false → Edges.tsx:92-96
  で全施策→中間目的の線がスキップされていた。