### PR TITLE
project-dialogue-exampleのaxiosをfetchに置き換え

### DIFF
--- a/examples/project-dialogue-example/package-lock.json
+++ b/examples/project-dialogue-example/package-lock.json
@@ -7,10 +7,10 @@
     "": {
       "name": "project-dialogue-example",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@goto-lab/pufu-editor": "^0.9.5",
         "@tailwindcss/typography": "^0.5.16",
-        "axios": "^1.7.2",
         "cors": "^2.8.5",
         "express": "^4.18.2",
         "react": "^18.2.0",
@@ -1431,11 +1431,6 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -1471,16 +1466,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/bail": {
@@ -1862,17 +1847,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -2043,14 +2017,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -2166,20 +2132,6 @@
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dependencies": {
         "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2396,25 +2348,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -2429,21 +2362,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -2615,20 +2533,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -4039,11 +3943,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/qs": {
       "version": "6.13.0",

--- a/examples/project-dialogue-example/package.json
+++ b/examples/project-dialogue-example/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@goto-lab/pufu-editor": "^0.9.5",
     "@tailwindcss/typography": "^0.5.16",
-    "axios": "^1.7.2",
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "react": "^18.2.0",

--- a/examples/project-dialogue-example/package.json
+++ b/examples/project-dialogue-example/package.json
@@ -5,7 +5,7 @@
   "description": "プロジェクト振り返りを対話形式で行うサンプルアプリケーション",
   "scripts": {
     "dev": "concurrently \"npm run server\" \"vite\"",
-    "install": "npm install && cd server && npm install && cd ..",
+    "postinstall": "cd server && npm install",
     "server": "node server/server.js",
     "build": "tsc && vite build",
     "preview": "vite preview"

--- a/examples/project-dialogue-example/server/package.json
+++ b/examples/project-dialogue-example/server/package.json
@@ -12,7 +12,6 @@
     "express": "^4.18.2",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
-    "axios": "^1.7.2",
     "@google/generative-ai": "^0.5.0"
   },
   "devDependencies": {

--- a/examples/project-dialogue-example/server/server.js
+++ b/examples/project-dialogue-example/server/server.js
@@ -1,7 +1,7 @@
 import express from "express";
 import cors from "cors";
 import dotenv from "dotenv";
-import axios from "axios";
+
 
 // 環境変数の読み込み - .envファイルを読み込み
 dotenv.config({ path: "./.env" });
@@ -617,15 +617,17 @@ app.post("/api/synthesize", async (req, res) => {
     } = req.body;
 
     // 音声クエリの作成
-    const queryResponse = await axios.post(
-      `${VOICEVOX_URL}/audio_query`,
-      null,
-      {
-        params: { text, speaker },
-      }
+    const queryParams = new URLSearchParams({ text, speaker: String(speaker) });
+    const queryResponse = await fetch(
+      `${VOICEVOX_URL}/audio_query?${queryParams}`,
+      { method: "POST" }
     );
 
-    const audioQuery = queryResponse.data;
+    if (!queryResponse.ok) {
+      throw new Error(`VOICEVOX audio_query error: ${queryResponse.status}`);
+    }
+
+    const audioQuery = await queryResponse.json();
 
     // パラメータの調整
     audioQuery.speedScale = speedScale;
@@ -636,17 +638,23 @@ app.post("/api/synthesize", async (req, res) => {
     audioQuery.postPhonemeLength = postPhonemeLength;
 
     // 音声合成
-    const synthesisResponse = await axios.post(
-      `${VOICEVOX_URL}/synthesis`,
-      audioQuery,
+    const synthesisParams = new URLSearchParams({ speaker: String(speaker) });
+    const synthesisResponse = await fetch(
+      `${VOICEVOX_URL}/synthesis?${synthesisParams}`,
       {
-        params: { speaker },
-        responseType: "arraybuffer",
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(audioQuery),
       }
     );
 
+    if (!synthesisResponse.ok) {
+      throw new Error(`VOICEVOX synthesis error: ${synthesisResponse.status}`);
+    }
+
     // 音声データをBase64で返す
-    const audioBase64 = Buffer.from(synthesisResponse.data).toString("base64");
+    const audioArrayBuffer = await synthesisResponse.arrayBuffer();
+    const audioBase64 = Buffer.from(audioArrayBuffer).toString("base64");
     res.json({ audio: audioBase64 });
   } catch (error) {
     console.error("音声合成エラー:", error.message);
@@ -657,8 +665,12 @@ app.post("/api/synthesize", async (req, res) => {
 // スピーカー一覧取得
 app.get("/api/speakers", async (req, res) => {
   try {
-    const response = await axios.get(`${VOICEVOX_URL}/speakers`);
-    res.json(response.data);
+    const response = await fetch(`${VOICEVOX_URL}/speakers`);
+    if (!response.ok) {
+      throw new Error(`VOICEVOX speakers error: ${response.status}`);
+    }
+    const data = await response.json();
+    res.json(data);
   } catch (error) {
     console.error("スピーカー取得エラー:", error.message);
     res.status(500).json({ error: "スピーカー情報の取得に失敗しました" });
@@ -668,7 +680,8 @@ app.get("/api/speakers", async (req, res) => {
 // ヘルスチェック
 app.get("/api/health", async (req, res) => {
   try {
-    await axios.get(`${VOICEVOX_URL}/version`);
+    const versionRes = await fetch(`${VOICEVOX_URL}/version`);
+    if (!versionRes.ok) throw new Error("VOICEVOX not available");
     res.json({ status: "ok", voicevox: "connected" });
   } catch (error) {
     res.status(503).json({ status: "error", voicevox: "disconnected" });

--- a/examples/project-dialogue-example/src/services/VoicevoxService.ts
+++ b/examples/project-dialogue-example/src/services/VoicevoxService.ts
@@ -1,5 +1,3 @@
-import axios from 'axios';
-
 export class VoicevoxService {
   private static instance: VoicevoxService;
   private audioContext: AudioContext | null = null;
@@ -46,18 +44,27 @@ export class VoicevoxService {
       console.log('[DEBUG] VoicevoxService.speak開始:', new Date().toISOString(), 'テキスト:', text.substring(0, 50) + '...');
       const startTime = performance.now();
       
-      const response = await axios.post('/api/synthesize', {
-        text,
-        speaker: options.speaker || 3, // ずんだもん
-        speedScale: options.speedScale || 1.2,
-        pitchScale: options.pitchScale || 0,
-        volumeScale: options.volumeScale || 1,
+      const response = await fetch('/api/synthesize', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          text,
+          speaker: options.speaker || 3, // ずんだもん
+          speedScale: options.speedScale || 1.2,
+          pitchScale: options.pitchScale || 0,
+          volumeScale: options.volumeScale || 1,
+        }),
       });
-      
+
+      if (!response.ok) {
+        throw new Error(`音声合成APIエラー: ${response.status}`);
+      }
+
       const apiTime = performance.now();
       console.log('[DEBUG] API応答完了:', (apiTime - startTime).toFixed(2) + 'ms');
 
-      const audioData = response.data.audio;
+      const responseData = await response.json();
+      const audioData = responseData.audio;
       const audioBuffer = this.base64ToArrayBuffer(audioData);
       
       const context = this.getAudioContext();
@@ -115,8 +122,10 @@ export class VoicevoxService {
 
   async checkConnection(): Promise<boolean> {
     try {
-      const response = await axios.get('/api/health');
-      return response.data.voicevox === 'connected';
+      const response = await fetch('/api/health');
+      if (!response.ok) return false;
+      const data = await response.json();
+      return data.voicevox === 'connected';
     } catch {
       return false;
     }


### PR DESCRIPTION
## Summary
- project-dialogue-exampleからaxios依存を削除し、ネイティブfetch APIに置き換え
- サーバー側（VOICEVOX関連エンドポイント）とクライアント側（VoicevoxService）の両方を移行
- 両方のpackage.jsonからaxiosを削除

## Test plan
- [x] サーバー起動確認（`npm run server`）
- [x] VOICEVOX音声合成が正常に動作すること
- [x] スピーカー一覧取得が正常に動作すること
- [x] ヘルスチェックエンドポイントが正常に動作すること
- [x] クライアント側のVoicevoxServiceが正常に動作すること