### PR TITLE
Use Node 22 for pnpm workflows

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,7 +13,7 @@ jobs:
           run_install: false
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/storybook-release.yml
+++ b/.github/workflows/storybook-release.yml
@@ -28,10 +28,10 @@ jobs:
         with:
           run_install: false
 
-      - name: Setup Node.js 20.x
+      - name: Setup Node.js 22.x
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
           cache: "pnpm"
 
       - name: Install Node Dependencies


### PR DESCRIPTION
## Summary

- Updates pnpm-based GitHub Actions workflows from Node.js 20.x to 22.x
- Fixes deploy failures caused by `pnpm@11.1.1` requiring Node.js >= 22.13 and `node:sqlite`

## Updated workflows

- `.github/workflows/storybook-release.yml`
- `.github/workflows/npm-publish.yml`

## Verification

- `node -v` -> `v22.16.0`
- `corepack pnpm --version` -> `11.1.1`
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm run build`
